### PR TITLE
Updated header 'more' link to no longer be relative

### DIFF
--- a/src/scripts/modules/header/header.tpl
+++ b/src/scripts/modules/header/header.tpl
@@ -132,7 +132,7 @@
 
       </li> -->
       <li class="m-header-item -default shape-more">
-        <a id="btnSubmenuMore" target="_blank" data-submenu="#submenuMore" title="More in GFW" data-stopnavigation="true" class="m-header-submenu-btn" href="/more">
+        <a id="btnSubmenuMore" target="_blank" data-submenu="#submenuMore" title="More in GFW" data-stopnavigation="true" class="m-header-submenu-btn" href="https://gfwpro.globalforestwatch.org/more">
           <div class='text-more'>
             More
             <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-h-explore"></use></svg>


### PR DESCRIPTION
One day we no longer want to hardcode in any prod or staging URL's, we want to make them all relative like they used to be (unlike this PR's change), but relative from the base URL of pro.globalforestwatch.org